### PR TITLE
Fixed the link to LW-ADD-ONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A curated list of awesome LispWorks extensions. Inspired by [awesome-python](htt
 
 ### IDE Extensions
 - [Color Theme](https://github.com/acelent/lw-editor-color-theme) - LispWorks Editor color theme addon
-- [LW-ADD-ONS](http://weitz.de/lw-add-ons/) - Some additions to the LispWorks IDE
+- [LW-ADD-ONS](https://common-lisp.net/~loliveira/ediware/lw-add-ons/_darcs/current/doc/) - Some additions to the LispWorks IDE, archive can be downloaded [here](http://weitz.de/files/lispOld.zip).
 
 
 ### Documentation


### PR DESCRIPTION
Link http://weitz.de/lw-add-ons/ now redirects to the page http://weitz.de/lisp.html which says:

```
Lisp stuff
Most of the Common Lisp libraries I once wrote are now available via GitHub at https://github.com/edicl. Please update your bookmarks or links.

If there's something that's not in that repository, you might find it at http://weitz.de/files/lispOld.zip. Let me know if you're interested in hosting/maintaining any of this.

My Lisp book is here.
```